### PR TITLE
Update CSS to mitigate an odd UI conflict with Carousel Combat Tracker

### DIFF
--- a/styles/Turns.css
+++ b/styles/Turns.css
@@ -19,7 +19,8 @@
 }
 
 .yourTurnBanner{
-  margin-left: 400px;
+  margin-left: 0px;
+  padding-left: 400px;
   margin-top: 150px;
   height: 155px;
 }
@@ -48,7 +49,7 @@
 .yourTurnBannerBackground{
   height: 180px;
   top:  -20px;
-  left: -400px;
+  left: 0px;
   background-color: var(--ADA_COMBATBANNER_colorTransparent);
   background-blend-mode: hard-light;
   background-repeat: repeat;


### PR DESCRIPTION
Fixes #6

Using padding instead of margin seems to avoid the conflict with Carousel Combat Tracker.